### PR TITLE
Feature/incorporate optimist commandline options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Avrodoc can be used in two modes of operation:
 To run as a command-line tool:
 
     $ npm install avrodoc -g
-    $ avrodoc my-schema.avsc [another-schema.avsc...] > my-documentation.html
+    $ avrodoc [my-schema.avsc [another-schema.avsc...]] [-o=my-documentation.html] [> my-documentation.html] [-- my-schema.avsc [another-schema.avsc]]
     # open my-documentation.html in a web browser
 
 To run as a web app:

--- a/bin/avrodoc
+++ b/bin/avrodoc
@@ -3,12 +3,25 @@
 var path = require('path'),
     fs = require('fs'),
     sys = require('util'),
-    content = require('../lib/static_content');
+    content = require('../lib/static_content'),
+    argv = require('optimist').alias('o', 'output').argv;
 
-var args = process.argv.slice(2); // argv[0] == node, argv[1] == avrodoc
-if (args.length === 0) {
-    sys.error('Usage: avrodoc schema1.avsc [schema2.avsc ...] > avrodoc.html');
-    process.exit(1);
+var inputFiles = null;
+var outputFile = null;
+
+// Determine list of input files file1.avsc file2.avsc
+if (argv._) {
+   inputFiles = argv._;
+}
+
+// Determine whether an output file is specified
+if (argv.output) {
+   outputFile = argv.output;
+}
+
+if (inputFiles == null || inputFiles.length === 0) {
+   sys.error('Usage: avrodoc schema1.avsc [schema2.avsc ...] > avrodoc.html');
+   process.exit(1);
 }
 
 function readJSON(filename) {
@@ -23,11 +36,23 @@ function readJSON(filename) {
     return parsed;
 }
 
-var schemata = args.map(function (filename) {
+var schemata = inputFiles.map(function (filename) {
     return {json: readJSON(filename), filename: filename};
 });
 
 content.topLevelHTML({inline: true, schemata: schemata}, function (err, html) {
-    if (err) throw err;
-    sys.puts(html);
+    if (err) {
+       throw err;
+    }
+    if (outputFile != null) {
+       fs.writeFile(outputFile, html, function (err) {
+          if (err) {
+             throw err;
+          } else {
+             console.log('Avrodoc saved to ' + outputFile)
+          }
+       });
+    } else {
+       sys.puts(html);
+    }
 });

--- a/bin/avrodoc
+++ b/bin/avrodoc
@@ -20,7 +20,7 @@ if (argv.output) {
 }
 
 if (inputFiles == null || inputFiles.length === 0) {
-   sys.error('Usage: avrodoc schema1.avsc [schema2.avsc ...] > avrodoc.html');
+   sys.error('Usage: avrodoc [my-schema.avsc [another-schema.avsc...]] [-o=my-documentation.html] [> my-documentation.html] [-- my-schema.avsc [another-schema.avsc]]');
    process.exit(1);
 }
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "uglify-js": "1.3.3",
     "less": "1.3.0",
     "underscore": "1.4.2",
-    "glob": "3.1.14"
+    "glob": "3.1.14",
+    "optimist": "0.3.5"
   },
   "devDependencies": {
     "jshint": "0.9.1"


### PR DESCRIPTION
I've gone ahead and done the work to incorporate the optimist js library in to avrodoc to support the following command line input options:

avrodoc input1.avsc input2.avsc --output=/tmp/newFile.html
avrodoc input1.avsc input2.avsc -o=/tmp/newFile.html
avrodoc input1.avsc input2.avsc --output /tmp/newFile.html
avrodoc input1.avsc input2.avsc -o /tmp/newFile.html
avrodoc -o /tmp/newFile.html -- input1.avsc input2.avsc
avrodoc --output /tmp/newFile.html -- input1.avsc input2.avsc
avrodoc --output /tmp/newFile.html -- -input1-with-hyphen.avsc

Please let me know when you've incorporated these changes as well as updated the npm website so we can pull a fresh copy down from there.

Resolves Issue #4 

Thank you!

Micah
