### PR TITLE
Changed less interpolation syntax

### DIFF
--- a/public/stylesheets/bootstrap/mixins.less
+++ b/public/stylesheets/bootstrap/mixins.less
@@ -558,13 +558,13 @@
   .core (@gridColumnWidth, @gridGutterWidth) {
 
     .spanX (@index) when (@index > 0) {
-      (~".span@{index}") { .span(@index); }
+      (.span@{index}) { .span(@index); }
       .spanX(@index - 1);
     }
     .spanX (0) {}
 
     .offsetX (@index) when (@index > 0) {
-      (~".offset@{index}") { .offset(@index); }
+      (.offset@{index}) { .offset(@index); }
       .offsetX(@index - 1);
     }
     .offsetX (0) {}
@@ -603,14 +603,14 @@
   .fluid (@fluidGridColumnWidth, @fluidGridGutterWidth) {
 
     .spanX (@index) when (@index > 0) {
-      (~".span@{index}") { .span(@index); }
+      (.span@{index}) { .span(@index); }
       .spanX(@index - 1);
     }
     .spanX (0) {}
 
     .offsetX (@index) when (@index > 0) {
-      (~'.offset@{index}') { .offset(@index); }
-      (~'.offset@{index}:first-child') { .offsetFirstChild(@index); }
+      (.offset@{index}) { .offset(@index); }
+      (.offset@{index}:first-child) { .offsetFirstChild(@index); }
       .offsetX(@index - 1);
     }
     .offsetX (0) {}
@@ -653,7 +653,7 @@
   .input(@gridColumnWidth, @gridGutterWidth) {
 
     .spanX (@index) when (@index > 0) {
-      (~"input.span@{index}, textarea.span@{index}, .uneditable-input.span@{index}") { .span(@index); }
+      (input.span@{index}) { .span(@index); }
       .spanX(@index - 1);
     }
     .spanX (0) {}


### PR DESCRIPTION
It seems some of the syntax for less has changed:

"(~"@var") selector interpolation is removed. Use @{var} in selectors to have variable selectors"

https://github.com/less/less.js/blob/master/CHANGELOG.md#140-beta-1--2

I'm not sure if there is a way to re-generate this in a better way, but this works for me.
