### PR TITLE
Popover down does not fit when using 13" screens

### DIFF
--- a/public/js/avrodoc.js
+++ b/public/js/avrodoc.js
@@ -48,7 +48,7 @@ function AvroDoc(input_schemata) {
 
             $(this).popover({
                 trigger: 'hover',
-                placement: 'bottom',
+                placement: 'right',
                 title: function () { return popover.title; },
                 content: function () { return popover.content; },
                 delay: {show: 200, hide: 50},


### PR DESCRIPTION
Currently the configuration of the bootstrap popover has the placement set to `bottom`. This means that smaller screens (for example a 13" MBP) would not be able to see the full content of the popover. By changing this to `right`, it would allow the content to be displayed correctly, without going outside the screen!

Discovered this problem today in an instance of avrodoc, and found it already reported at https://github.com/ga4gh/dwg-website/issues/4
