### PR TITLE
Improve readability of list pane links

### DIFF
--- a/public/stylesheets/style.less
+++ b/public/stylesheets/style.less
@@ -68,7 +68,6 @@
     // General link styling
     a {
       display: block;
-      font-weight: lighter;
       padding: 4px 0;
       text-decoration: none;
       .text-overflow();


### PR DESCRIPTION
Typography was too thin.

Before:
![before](https://cloud.githubusercontent.com/assets/189174/23708623/d6aef3b0-0416-11e7-9005-cfaa9a32c551.jpg)

After:
![after](https://cloud.githubusercontent.com/assets/189174/23708627/daa06030-0416-11e7-80ab-f300d2969bd8.jpg)
